### PR TITLE
fix: output content on landing page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
 <main class="main" role="main">
-
+    {{.Content}}
 </main>
 {{ end }}


### PR DESCRIPTION
Add `{{.Content}}` to `index.html` template

fix #44
